### PR TITLE
Fix `NodeArrayFutureTest.testTimeoutIsSpread()`

### DIFF
--- a/src/test/java/org/mortbay/jetty/orchestrator/NodeArrayFutureTest.java
+++ b/src/test/java/org/mortbay/jetty/orchestrator/NodeArrayFutureTest.java
@@ -131,8 +131,12 @@ public class NodeArrayFutureTest extends AbstractSshTest
         try (Cluster cluster = new Cluster(cfg))
         {
             NodeArray nodeArray = cluster.nodeArray("my-array");
-            NodeArrayFuture future = nodeArray.executeOnAll(tools -> Thread.sleep(600));
-            assertThrows(TimeoutException.class, () -> future.get(1, TimeUnit.SECONDS));
+            NodeArrayFuture future = nodeArray.executeOnAll(tools ->
+            {
+                int id = tools.barrier("testTimeoutIsSpread-barrier", 2).await();
+                Thread.sleep(1600L * (id + 1L));
+            });
+            assertThrows(TimeoutException.class, () -> future.get(3, TimeUnit.SECONDS));
         }
     }
 }


### PR DESCRIPTION
Just make sure one of the lambdas execute for longer than the future's timeout.

Fixes #192 